### PR TITLE
Add frr.vtysh.pathspace option (=> vtysh -N)

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -78,8 +78,8 @@ func (e *Exporters) SetVTYSHTimeout(timeout time.Duration) {
 }
 
 // SetVTYSHPathspace sets the frr config path prefix (-N option for vtysh)
-func (e *Exporters) SetVTYSHPathspace(ns string) {
-	vtyshPathspace = &ns
+func (e *Exporters) SetVTYSHPathspace(s string) {
+	vtyshPathspace = &s
 }
 
 // SetVTYSHSudo sets the first command to execute vtysh if sudo is enabled.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -8,8 +8,7 @@ import (
 	"github.com/prometheus/common/log"
 )
 
-// The namespace used by all metrics.
-const namespace = "frr"
+const metric_namespace = "frr"
 
 var (
 	frrTotalScrapeCount = 0.0
@@ -25,6 +24,7 @@ var (
 	vtyshPath    string
 	vtyshTimeout time.Duration
 	vtyshSudo    bool
+	vtyshPathspace *string
 )
 
 // CLIHelper is used to populate flags.
@@ -75,6 +75,11 @@ func (e *Exporters) SetVTYSHPath(path string) {
 // SetVTYSHTimeout sets the path of vtysh.
 func (e *Exporters) SetVTYSHTimeout(timeout time.Duration) {
 	vtyshTimeout = timeout
+}
+
+// SetVTYSHPathspace sets the frr config path prefix (-N option for vtysh)
+func (e *Exporters) SetVTYSHPathspace(ns string) {
+	vtyshPathspace = &ns
 }
 
 // SetVTYSHSudo sets the first command to execute vtysh if sudo is enabled.
@@ -150,11 +155,11 @@ func runCollector(ch chan<- prometheus.Metric, errCh chan<- int, collector *Coll
 }
 
 func promDesc(metricName string, metricDescription string, labels []string) *prometheus.Desc {
-	return prometheus.NewDesc(namespace+"_"+metricName, metricDescription, labels, nil)
+	return prometheus.NewDesc(metric_namespace+"_"+metricName, metricDescription, labels, nil)
 }
 
 func colPromDesc(subsystem string, metricName string, metricDescription string, labels []string) *prometheus.Desc {
-	return prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, metricName), metricDescription, labels, nil)
+	return prometheus.NewDesc(prometheus.BuildFQName(metric_namespace, subsystem, metricName), metricDescription, labels, nil)
 }
 
 func newGauge(ch chan<- prometheus.Metric, descName *prometheus.Desc, metric float64, labels ...string) {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -21,9 +21,9 @@ var (
 		"frrCollectorUp":    promDesc("collector_up", "Whether the collector's last scrape was successful (1 = successful, 0 = unsuccessful).", frrLabels),
 		"frrUp":             promDesc("up", "Whether FRR is currently up.", nil),
 	}
-	vtyshPath    string
-	vtyshTimeout time.Duration
-	vtyshSudo    bool
+	vtyshPath      string
+	vtyshTimeout   time.Duration
+	vtyshSudo      bool
 	vtyshPathspace *string
 )
 
@@ -84,7 +84,7 @@ func (e *Exporters) SetVTYSHPathspace(ns string) {
 
 // SetVTYSHSudo sets the first command to execute vtysh if sudo is enabled.
 func (e *Exporters) SetVTYSHSudo(enable bool) {
-        vtyshSudo = enable
+	vtyshSudo = enable
 }
 
 // Describe implemented as per the prometheus.Collector interface.

--- a/collector/command.go
+++ b/collector/command.go
@@ -12,13 +12,25 @@ func execVtyshCommand(args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), vtyshTimeout)
 	defer cancel()
 
+	var a []string
+	var executable string
+
 	if vtyshSudo == true {
-		a := []string{vtyshPath}
-		a = append(a, args...)
-		output, err = exec.CommandContext(ctx, "/usr/bin/sudo", a...).Output()
+		a = []string{vtyshPath}
+		executable = "/usr/bin/sudo"
 	} else {
-		output, err = exec.CommandContext(ctx, vtyshPath, args...).Output()
+		a = []string{}
+		executable = vtyshPath
 	}
+
+	if vtyshPathspace != nil {
+		n_opt := []string{"-N", *vtyshPathspace}
+		a = append(a, n_opt...)
+	}
+
+	a = append(a, args...)
+
+	output, err = exec.CommandContext(ctx, executable, a...).Output()
 
 	if err != nil {
 		return nil, err

--- a/frr_exporter.go
+++ b/frr_exporter.go
@@ -18,6 +18,7 @@ var (
 	listenAddress   = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9342").String()
 	telemetryPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 	frrVTYSHPath    = kingpin.Flag("frr.vtysh.path", "Path of vtysh.").Default("/usr/bin/vtysh").String()
+	frrVTYSHPathspace    = kingpin.Flag("frr.vtysh.pathspace", "Config prefix to be passed to vtysh (-N)").String()
 	frrVTYSHTimeout = kingpin.Flag("frr.vtysh.timeout", "The timeout when running vtysh commands (default 20s).").Default("20s").String()
 	frrVTYSHSudo    = kingpin.Flag("frr.vtysh.sudo", "Enable sudo when executing vtysh commands.").Bool()
 
@@ -78,6 +79,10 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	frrTimeout, _ := time.ParseDuration(*frrVTYSHTimeout)
 	ne.SetVTYSHTimeout(frrTimeout)
 	ne.SetVTYSHSudo(*frrVTYSHSudo)
+
+	if frrVTYSHPathspace != nil {
+		ne.SetVTYSHPathspace(*frrVTYSHPathspace)
+	}
 
 	registry.Register(ne)
 

--- a/frr_exporter.go
+++ b/frr_exporter.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	listenAddress   = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9342").String()
-	telemetryPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-	frrVTYSHPath    = kingpin.Flag("frr.vtysh.path", "Path of vtysh.").Default("/usr/bin/vtysh").String()
-	frrVTYSHPathspace    = kingpin.Flag("frr.vtysh.pathspace", "Config prefix to be passed to vtysh (-N)").String()
-	frrVTYSHTimeout = kingpin.Flag("frr.vtysh.timeout", "The timeout when running vtysh commands (default 20s).").Default("20s").String()
-	frrVTYSHSudo    = kingpin.Flag("frr.vtysh.sudo", "Enable sudo when executing vtysh commands.").Bool()
+	listenAddress     = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9342").String()
+	telemetryPath     = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+	frrVTYSHPath      = kingpin.Flag("frr.vtysh.path", "Path of vtysh.").Default("/usr/bin/vtysh").String()
+	frrVTYSHPathspace = kingpin.Flag("frr.vtysh.pathspace", "Config prefix to be passed to vtysh (-N)").String()
+	frrVTYSHTimeout   = kingpin.Flag("frr.vtysh.timeout", "The timeout when running vtysh commands (default 20s).").Default("20s").String()
+	frrVTYSHSudo      = kingpin.Flag("frr.vtysh.sudo", "Enable sudo when executing vtysh commands.").Bool()
 
 	collectors = []*collector.Collector{}
 )


### PR DESCRIPTION
If you have multiple instances of frr running on the same machine
(e.g. because they are responsible for different network namespaces)
this option is necessary to be able to export metrics from all frr
instances.

vtysh supports the -N option (they call it pathspace, the prefix for frr config)

This commit adds support for passing -N to vtysh

Upstream MR: https://github.com/tynany/frr_exporter/pull/32