### PR TITLE
Fix bug where collector will stay down forever after any error

### DIFF
--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -68,6 +68,7 @@ func (*BGPCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implemented as per the prometheus.Collector interface.
 func (c *BGPCollector) Collect(ch chan<- prometheus.Metric) {
+	bgpErrors = []error{}
 	collectBGP(ch, "ipv4")
 }
 
@@ -113,6 +114,7 @@ func (*BGP6Collector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implemented as per the prometheus.Collector interface.
 func (c *BGP6Collector) Collect(ch chan<- prometheus.Metric) {
+	bgp6Errors = []error{}
 	collectBGP(ch, "ipv6")
 }
 
@@ -196,6 +198,7 @@ func processBgpL2vpnEvpnSummary(ch chan<- prometheus.Metric, jsonBGPL2vpnEvpnSum
 
 // Collect implemented as per the prometheus.Collector interface.
 func (c *BGPL2VPNCollector) Collect(ch chan<- prometheus.Metric) {
+	bgpL2VPNErrors = []error{}
 	collectBGP(ch, "l2vpn")
 
 	jsonBGPL2vpnEvpnSum, err := getBgpL2vpnEvpnSummary()

--- a/collector/vrrp.go
+++ b/collector/vrrp.go
@@ -112,6 +112,7 @@ func getVRRPDesc() map[string]*prometheus.Desc {
 }
 
 func collectVRRP(ch chan<- prometheus.Metric) {
+	vrrpErrors = []error{}
 	jsonVRRPInfo, err := getVRRPInfo()
 	if err != nil {
 		totalVRRPErrors++


### PR DESCRIPTION
Because in the BGP and VRRP collectors, the error list
will never be reset, the collectors report as down forever
until the exporter is restarted after just one error